### PR TITLE
Allow more than one event type to be registered

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Usage
 var hotkey = require('react-hotkey');
 // Enable event listening, can be safely called multiple times
 hotkey.activate();
+// The default is to listen for 'keyup' but you can listen to others by passing an argument
+hotkey.activate('keydown');
+
 
 React.createClass({
     mixins: [hotkey.Mixin('handleHotkey')],

--- a/__tests__/on-and-off-test.js
+++ b/__tests__/on-and-off-test.js
@@ -19,7 +19,7 @@ describe('on-and-off', function() {
             triggerKey(document);
             expect(events.length).toBe(0);
         });
-        it('should start responding after disable() is called', function() {
+        it('should start responding to keyup only after activate() is called', function() {
             triggerKey(document);
             expect(events.length).toBe(0);
             var result = hotkey.activate();
@@ -27,8 +27,24 @@ describe('on-and-off', function() {
             expect(result).toBe(hotkey);
             triggerKey(document);
             expect(events.length).toBe(1);
+            triggerKey(document, null, 'keydown');
+            expect(events.length).toBe(1);
         });
+        it('should respond to both after activate() and activate("keydown") is called', function() {
+            triggerKey(document);
+            expect(events.length).toBe(0);
+            var result = hotkey.activate("keydown");
+            result = hotkey.activate();
+            // Can be chained
+            expect(result).toBe(hotkey);
+            triggerKey(document);
+            expect(events.length).toBe(1);
+            triggerKey(document, null, 'keydown');
+            expect(events.length).toBe(2);
+        });
+
     });
+
 
     describe("activate has been called", function() {
         beforeEach(function() {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var EventListener = require('react/lib/EventListener');
 var SyntheticKeyboardEvent = require('react/lib/SyntheticKeyboardEvent');
 
-var documentListener;
+var documentListener = {};
 /**
  * Enable the global event listener. Is idempotent.
  */
@@ -9,18 +9,21 @@ exports.activate = function(event) {
     if (!event) {
         event = 'keyup';
     }
-    if (!documentListener) {
-        documentListener = EventListener.listen(document, event, handle);
+    if (!documentListener[event]) {
+        documentListener[event] = EventListener.listen(document, event, handle);
     }
     return exports;
 };
 /**
  * Disable the global event listener. Is idempotent.
  */
-exports.disable = function() {
-    if (documentListener) {
-        documentListener.remove();
-        documentListener = null;
+exports.disable = function(event) {
+    if (!event) {
+        event = 'keyup';
+    }
+    if (documentListener[event]) {
+        documentListener[event].remove();
+        documentListener[event] = null;
     }
 };
 

--- a/test-utils.js
+++ b/test-utils.js
@@ -1,8 +1,8 @@
 /*eslint-env browser */
 exports.triggerKey = triggerKey;
-function triggerKey(target, eventData) {
+function triggerKey(target, eventData, eventType) {
     var event = document.createEvent('KeyboardEvent');
-    event.initEvent('keyup', true, true);
+    event.initEvent(eventType || 'keyup', true, true);
     Object.keys(eventData || {}).forEach(function(k) {
         event[k] = eventData[k];
     });


### PR DESCRIPTION
I needed to listen to both keyup and keydown. This slight refactor lets that happen with no breakage to existing usage.

Thanks!