### PR TITLE
Add non-mixin interface of addHandler and removeHandler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,32 @@ React.createClass({
 })
 ```
 
+React Mixins do not work with ES2015. Instead one may use the `addHandler` and `removeHandler` functions:
+
+```js
+import React from 'react';
+import hotkey from 'react-hotkey';
+hotkey.activate();
+
+class MyComponent extends React.Component {
+    constructor() {
+        this.hotkeyHandler = this.handleHotkey.bind(this);
+    }
+
+    handleHotkey(e) {
+        console.log("hotkey", e);
+    }
+
+    componentDidMount() {
+        hotkey.addHandler(this.hotkeyHandler);
+    }
+
+    componentWillUnmount() {
+        hotkey.removeHandler(this.hotkeyHandler);
+    }
+}
+```
+
 
 Acknowledgements
 ----------------

--- a/__tests__/interface-test.js
+++ b/__tests__/interface-test.js
@@ -11,6 +11,12 @@ describe('exports', function() {
     it('should provide disable function', function() {
         expect(hotkey.disable).toEqual(jasmine.any(Function));
     });
+    it('should provide addHandler function', function() {
+        expect(hotkey.addHandler).toEqual(jasmine.any(Function));
+    });
+    it('should provide removeHandler function', function() {
+        expect(hotkey.removeHandler).toEqual(jasmine.any(Function));
+    });
     it('should provide Mixin', function() {
         expect(hotkey.Mixin).toEqual(jasmine.any(Function));
     });

--- a/index.js
+++ b/index.js
@@ -31,6 +31,25 @@ exports.disable = function(event) {
 var handlers = [];
 
 /**
+ * Adds the function `handler` to the array of handlers invoked
+ * upon activated keyboard events.
+ */
+exports.addHandler = function(handler) {
+    handlers.push(handler);
+};
+
+/**
+ * Removes the function `handler`, which was previously added with
+ * `addHandler`, from the array of keyboard event handlers.
+ */
+exports.removeHandler = function(handler) {
+    var index = handlers.indexOf(handler);
+    if (index >= 0)
+        handlers.splice(index, 1);
+};
+
+
+/**
  * Mixin that calls `handlerName` on your component if it is mounted and a
  * key event has bubbled up to the document
  */


### PR DESCRIPTION
As discussed in  #5 (but doesn't close it since that was actually about decorators), this is needed so that this library can be used with ES2015 which doesn't support mixins.

